### PR TITLE
[Bitrise] Fix node modules caching

### DIFF
--- a/generators/bitrise/templates/bitrise.yml
+++ b/generators/bitrise/templates/bitrise.yml
@@ -88,7 +88,7 @@ workflows:
     - cache-push@0.9.3:
         inputs:
         - cache_paths: |-
-            ./$REACT_NATIVE_DIRECTORY/node_modules -> package.json
+            ./$REACT_NATIVE_DIRECTORY/node_modules -> ./$REACT_NATIVE_DIRECTORY/package.json
             $HOME/.nvm -> $HOME/.nvm/package.json
             $HOME/.gradle
             $GEM_HOME


### PR DESCRIPTION
Also proposing syntax `[GENERATOR] COMMIT_MESSAGE` for commit messages