### PR TITLE
Fix CircleCI

### DIFF
--- a/generators/circleci/README.md
+++ b/generators/circleci/README.md
@@ -4,6 +4,6 @@
 
 In order to make circleCI working on your app, you need to create a circle.yml file by running
 
-`yo rn-toolbox:circle`
+`yo rn-toolbox:circleci`
 
 Then you have to configure the branch on which you want to trigger circleCI webhook directly on GitHub :)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "generators/assets",
     "generators/bitrise",
     "generators/jest",
-    "generators/circle",
+    "generators/circleci",
     "generators/upgrade"
   ],
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-rn-toolbox",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "React-Native generators to kickstart your project",
   "scripts": {
     "test": "node test.js"


### PR DESCRIPTION
Recent changes made some uncaught problems:
* (package.json) npm and yarn ignore the `circleci` folder when downloading files
* (README) the related command is not `yo rn-toolbox:circle` anymore 

This PR fixes these issues and bumps the package version.