### PR TITLE
[Fastlane] Remove extra call to match in Fastfile for iOS

### DIFF
--- a/generators/fastlane-setup/templates/fastlane/Fastfile
+++ b/generators/fastlane-setup/templates/fastlane/Fastfile
@@ -38,9 +38,6 @@ platform :ios do
       app_name: ENV['IOS_APP_NAME'],
       skip_itc: true
     )
-    match(
-      type: 'development'
-    )
     match()
   end
 


### PR DESCRIPTION
This should not be necessary as match now supports entreprise
provisioning profile (and now documented: https://github.com/fastlane/fastlane/commit/569bd4e84f810bcac4c5c138f91daf2fe0efc747)

Need testing on a blank project.
I've tested on an existing project by removing the first call to match and it's working great.