### PR TITLE
fix: Change gradle secrets namings

### DIFF
--- a/generators/fastlane-setup/templates/gradleSigning
+++ b/generators/fastlane-setup/templates/gradleSigning
@@ -1,8 +1,8 @@
     signingConfigs {
         release {
             storeFile file(String.valueOf(System.getenv("GRADLE_KEYSTORE")))
-            storePassword System.getenv("GRADLE_KEYSTORE_PASSWORD")
-            keyAlias System.getenv("GRADLE_KEYSTORE_ALIAS")
-            keyPassword System.getenv("GRADLE_KEYSTORE_ALIAS_PASSWORD")
+            storePassword System.getenv("GRADLE_STORE_PASSWORD")
+            keyAlias System.getenv("GRADLE_KEY_ALIAS")
+            keyPassword System.getenv("GRADLE_KEY_PASSWORD")
         }
     }


### PR DESCRIPTION
More explicit namings for fastlane secret vars