### PR TITLE
Add ipad portrait image support for ios 7-9

### DIFF
--- a/generators/assets/templates/ios/LaunchImageLaunchimageContents.json
+++ b/generators/assets/templates/ios/LaunchImageLaunchimageContents.json
@@ -110,7 +110,23 @@
       "filename" : "Default-Portrait@2x.png",
       "extent" : "full-screen",
       "scale" : "2x"
-    }
+    },
+    {
+      "orientation" : "portrait",
+      "idiom" : "ipad",
+      "filename" : "Default-Portrait.png",
+      "extent" : "full-screen",
+      "minimum-system-version" : "7.0",
+      "scale" : "1x"
+    },
+    {
+      "orientation" : "portrait",
+      "idiom" : "ipad",
+      "filename" : "Default-Portrait@2x.png",
+      "extent" : "full-screen",
+      "minimum-system-version" : "7.0",
+      "scale" : "2x"
+    },
   ],
   "info" : {
     "version" : 1,


### PR DESCRIPTION
On Ipad the portrait image is not being generated. Apparently, you need to set the mimium version to 7, otherwise Xcode only replaces the the ipads for ios 5,6. At least this is how it worked for me in xcode 9.0. 

Before:
<img width="326" alt="screen shot 2017-11-03 at 2 17 33 am" src="https://user-images.githubusercontent.com/6276582/32340562-4ff767b4-c03e-11e7-874d-c86d95e6d191.png">
<img width="348" alt="screen shot 2017-11-03 at 2 19 29 am" src="https://user-images.githubusercontent.com/6276582/32340563-50271c20-c03e-11e7-9b57-66f6ea8692a2.png">

After: 
<img width="479" alt="screen shot 2017-11-03 at 2 20 31 am" src="https://user-images.githubusercontent.com/6276582/32340590-5e51c124-c03e-11e7-977c-239950667b2b.png">

