### PR TITLE
Remove <2.4 Ruby version limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,10 @@ In an existing React Native project, our generator contains sub-generators that 
 ## Requirements
 
 - [ ] You need `node > 6` installed
-- [ ] Ruby > `2.2.3` (and < `2.4`*)
+- [ ] Ruby > `2.2.3`
 - [ ] Bundler installed (`gem install bundler`)
 - [ ] Yeoman installed (`npm i -g yo`)
 - [ ] Yarn installed (`npm i -g yarn`)
-
-\* Some gem dependencies (see issue [#51](https://github.com/bamlab/generator-rn-toolbox/pull/51)) are not compatible with Ruby >= `2.4` (as of 2017-01-11).
 
 ## Usage
 


### PR DESCRIPTION
This has been resolved quite some time ago.

https://github.com/bamlab/generator-rn-toolbox/pull/51
https://github.com/fastlane/fastlane/issues/7673
https://github.com/CocoaPods/CocoaPods/issues/6299