### PR TITLE
fix(fastlane env): fix fastlane env file GYM_OUTPUT_NAME

### DIFF
--- a/generators/fastlane-env/templates/fastlane/env
+++ b/generators/fastlane-env/templates/fastlane/env
@@ -23,7 +23,7 @@ MATCH_TYPE='<%= certificateType %>'
 ### IOS GYM ###
 GYM_SCHEME='<%= projectName %>'
 GYM_OUTPUT_DIRECTORY='dist'
-GYM_OUTPUT_NAME='app.ipa'
+GYM_OUTPUT_NAME='app'
 
 ### IOS HOCKEY APP AND APP CENTER ###
 IOS_IPA_PATH='./dist/app.ipa'


### PR DESCRIPTION
the correct output name does not contain the extension (.ipa), it's automatically added on build