### PR TITLE
feat: allow users to specify directory to save icon assets

### DIFF
--- a/generators/assets/imageGenerator.js
+++ b/generators/assets/imageGenerator.js
@@ -131,11 +131,11 @@ const generateIosIcons = (iconSource, iosIconFolder) =>
   ));
 
 
-const generateAndroidIcons = (iconSource, assetsOutputPath) =>
+const generateAndroidIcons = (iconSource, assetsOutputPath, androidSrcDirectory) =>
   Promise.all(androidIconSizes.map(size =>
     generateResizedAssets(
       iconSource,
-      `${assetsOutputPath}/android/app/src/main/res/mipmap-${size.density}/ic_launcher.png`,
+      `${assetsOutputPath}/android/app/src/${androidSrcDirectory}/res/mipmap-${size.density}/ic_launcher.png`,
       size.value
     )
   ));
@@ -150,21 +150,21 @@ const generateIosSplashScreen = (splashSource, iosSplashFolder) =>
     )
   ));
 
-const generateAndroidSplashScreen = (splashSource, assetsOutputPath) =>
+const generateAndroidSplashScreen = (splashSource, assetsOutputPath, androidSrcDirectory) =>
   androidSplashSizes.map(size =>
     generateResizedAssets(
       splashSource,
-      `${assetsOutputPath}/android/app/src/main/res/drawable-${size.density}/launch_screen.png`,
+      `${assetsOutputPath}/android/app/src/${androidSrcDirectory}/res/drawable-${size.density}/launch_screen.png`,
       size.width,
       size.height
     )
   );
 
-const generateAndroidNotificationIcons = (iconSource, assetsOutputPath) =>
+const generateAndroidNotificationIcons = (iconSource, assetsOutputPath, androidSrcDirectory) =>
   androidNotificationIconSizes.map(size =>
     generateResizedAssets(
       iconSource,
-      `${assetsOutputPath}/android/app/src/main/res/mipmap-${size.density}/ic_notification.png`,
+      `${assetsOutputPath}/android/app/src/${androidSrcDirectory}/res/mipmap-${size.density}/ic_notification.png`,
       size.value
     )
   );

--- a/generators/assets/index.js
+++ b/generators/assets/index.js
@@ -38,6 +38,16 @@ class ResourcesGenerator extends Base {
       desc: 'Name of your react-native project',
       default: '.',
     });
+    this.option('androidSrcDirectory', {
+      type: asset => asset,
+      desc: 'The directory under `src` to save the assets',
+      default: 'main',
+    });
+    this.option('iosAssetName', {
+      type: asset => asset,
+      desc: 'The name of the asset',
+      default: 'AppIcon',
+    });
   }
 
   initializing() {
@@ -105,7 +115,7 @@ class ResourcesGenerator extends Base {
   _setupIosIcons() {
     if (!this.ios || !this.options.icon) return null;
 
-    const iosIconFolder = `${this.options.assetsOutputPath}/ios/${this.projectName}/Images.xcassets/AppIcon.appiconset`;
+    const iosIconFolder = `${this.options.assetsOutputPath}/ios/${this.projectName}/Images.xcassets/${this.options.iosAssetName}.appiconset`;
 
     this.fs.copyTpl(
       this.templatePath('ios/AppIconsetContents.json'),
@@ -117,7 +127,7 @@ class ResourcesGenerator extends Base {
 
   _setupAndroidIcons() {
     if (!this.android || !this.options.icon) return null;
-    return imageGenerator.generateAndroidIcons(this.options.icon, this.options.assetsOutputPath);
+    return imageGenerator.generateAndroidIcons(this.options.icon, this.options.assetsOutputPath, this.options.androidSrcDirectory);
   }
 
   _setupAndroidNotificationIcons() {
@@ -167,17 +177,17 @@ class ResourcesGenerator extends Base {
     return getTopLeftPixelColor.then((splashBackgroundColor) => {
       this.fs.copyTpl(
         this.templatePath('android/colors.xml'),
-        `${this.options.assetsOutputPath}/android/app/src/main/res/values/colors.xml`,
+        `${this.options.assetsOutputPath}/android/app/src/${this.options.androidSrcDirectory}/res/values/colors.xml`,
         { splashBackgroundColor }
       );
       this.fs.copyTpl(
         this.templatePath('android/launch_screen_bitmap.xml'),
-        `${this.options.assetsOutputPath}/android/app/src/main/res/drawable/launch_screen_bitmap.xml`
+        `${this.options.assetsOutputPath}/android/app/src/${this.options.androidSrcDirectory}/res/drawable/launch_screen_bitmap.xml`
       );
 
       this.fs.copyTpl(
         this.templatePath('android/styles.xml'),
-        `${this.options.assetsOutputPath}/android/app/src/main/res/values/styles.xml`
+        `${this.options.assetsOutputPath}/android/app/src/${this.options.androidSrcDirectory}/res/values/styles.xml`
       );
 
       return imageGenerator.generateAndroidSplashScreen(


### PR DESCRIPTION
when trying to make icons for different variants/flavors, users can't select where to put them. This allows for the selection of that, falling back to the original values.