### PR TITLE
fix: Handle android back button in navigation

### DIFF
--- a/generators/base/templates/src/RootNavigation.js
+++ b/generators/base/templates/src/RootNavigation.js
@@ -1,9 +1,10 @@
 // @flow
 
 import React, { Component } from 'react';
+import { BackHandler } from 'react-native';
 import { connect } from 'react-redux';
 
-import { StackNavigator, addNavigationHelpers } from 'react-navigation';
+import { StackNavigator, addNavigationHelpers, NavigationActions } from 'react-navigation';
 
 import * as Pages from '<%= appName %>/src/pages';
 
@@ -14,6 +15,21 @@ export const AppNavigator = StackNavigator({
 });
 
 class App extends React.Component {
+  componentDidMount() {
+    BackHandler.addEventListener('hardwareBackPress', this.onBackPress);
+  }
+  componentWillUnmount() {
+    BackHandler.removeEventListener('hardwareBackPress', this.onBackPress);
+  }
+  onBackPress = () => {
+    const { dispatch, nav } = this.props;
+    if (nav.index === 0) {
+      return false;
+    }
+    dispatch(NavigationActions.back());
+    return true;
+  };
+
   render() {
     return (
       <AppNavigator


### PR DESCRIPTION
With redux, the navigator didn't handle the android back button.
Fix comes from : [https://reactnavigation.org/docs/guides/redux#Handling-the-Hardware-Back-Button-in-Android](https://reactnavigation.org/docs/guides/redux#Handling-the-Hardware-Back-Button-in-Android)
