### PR TITLE
fix(assets): Pass androidSrcDirectory to generateAndroidNotificationIcons

### DIFF
--- a/generators/assets/index.js
+++ b/generators/assets/index.js
@@ -134,7 +134,8 @@ class ResourcesGenerator extends Base {
     if (!this.options['android-notification-icon']) return null;
     return imageGenerator.generateAndroidNotificationIcons(
       this.options['android-notification-icon'],
-      this.options.assetsOutputPath
+      this.options.assetsOutputPath,
+      this.options.androidSrcDirectory
     );
   }
 


### PR DESCRIPTION
This fixes `undefined` showing up in the generated file path